### PR TITLE
AUR Makepkg + user's system unit files

### DIFF
--- a/extra/aur/.gitignore
+++ b/extra/aur/.gitignore
@@ -1,0 +1,5 @@
+config
+pkg
+src
+sunpaper
+sunpaper-*.pkg.tar.zst

--- a/extra/aur/PKGBUILD
+++ b/extra/aur/PKGBUILD
@@ -1,0 +1,54 @@
+# Maintainer: Your Name <youremail@domain.com>
+
+pkgname=sunpaper-git
+pkgver=r88.3336299
+pkgrel=1
+pkgdesc=""
+arch=("any")
+url="https://github.com/hexive/sunpaper"
+license=('GPL')
+groups=()
+depends=('sunwait' 'wallutils')
+makedepends=('git') 
+provides=("${pkgname%-git}")
+conflicts=("${pkgname%-git}")
+replaces=()
+backup=()
+options=()
+install=
+# source=('git+https://github.com/hexive/sunpaper.git')
+source=('git+https://github.com/nmiculinic/sunpaper.git')
+noextract=()
+md5sums=('SKIP')
+
+pkgver() {
+	cd "$srcdir/${pkgname%-git}"
+
+
+# The examples below are not absolute and need to be adapted to each repo. The
+# primary goal is to generate version numbers that will increase according to
+# pacman's version comparisons with later commits to the repo. The format
+# VERSION='VER_NUM.rREV_NUM.HASH', or a relevant subset in case VER_NUM or HASH
+# are not available, is recommended.
+
+# Git, tags available
+	# printf "%s" "$(git describe --long | sed 's/\([^-]*-\)g/r\1/;s/-/./g')"
+
+# Git, no tags available
+	printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+package() {
+    # had some issues getting this working
+    install -D -m644 ../sunpaper.service "$pkgdir/usr/lib/systemd/user/sunpaper.service"
+    install -D -m644 ../sunpaper.timer "$pkgdir/usr/lib/systemd/user/sunpaper.timer"
+
+	cd "$srcdir/${pkgname%-git}"
+    install -D -m755 sunpaper.sh "$pkgdir/usr/bin/sunpaper.sh"
+    mkdir -p "$pkgdir/usr/share/sunpaper"
+    cp -dr images "$pkgdir/usr/share/sunpaper/images"
+    install -D -m644 extra/config "$pkgdir/usr/share/sunpaper/config"
+
+    # install -D -m644 extra/aur/sunpaper.service "$pkgdir/usr/lib/systemd/user/sunpaper.service"
+    # install -D -m644 extra/aur/sunpaper.timer "$pkgdir/usr/lib/systemd/user/sunpaper.timer"
+}

--- a/extra/aur/PKGBUILD
+++ b/extra/aur/PKGBUILD
@@ -1,7 +1,9 @@
+# Put the right maintainer email & handle the AUR upload
 # Maintainer: Your Name <youremail@domain.com>
 
 pkgname=sunpaper-git
-pkgver=r88.3336299
+# This has to be adapted
+pkgver=r90.8e41841
 pkgrel=1
 pkgdesc=""
 arch=("any")
@@ -16,6 +18,7 @@ replaces=()
 backup=()
 options=()
 install=
+# This has to be reverted before merging
 # source=('git+https://github.com/hexive/sunpaper.git')
 source=('git+https://github.com/nmiculinic/sunpaper.git')
 noextract=()
@@ -24,24 +27,19 @@ md5sums=('SKIP')
 pkgver() {
 	cd "$srcdir/${pkgname%-git}"
 
-# Git, tags available
+    # Git, tags available
 	# printf "%s" "$(git describe --long | sed 's/\([^-]*-\)g/r\1/;s/-/./g')"
 
-# Git, no tags available
+    # Git, no tags available
 	printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
 }
 
 package() {
-    # had some issues getting this working
-    install -D -m644 ../sunpaper.service "$pkgdir/usr/lib/systemd/user/sunpaper.service"
-    install -D -m644 ../sunpaper.timer "$pkgdir/usr/lib/systemd/user/sunpaper.timer"
-
 	cd "$srcdir/${pkgname%-git}"
     install -D -m755 sunpaper.sh "$pkgdir/usr/bin/sunpaper.sh"
     mkdir -p "$pkgdir/usr/share/sunpaper"
     cp -dr images "$pkgdir/usr/share/sunpaper/images"
     install -D -m644 extra/config "$pkgdir/usr/share/sunpaper/config"
-
-    # install -D -m644 extra/aur/sunpaper.service "$pkgdir/usr/lib/systemd/user/sunpaper.service"
-    # install -D -m644 extra/aur/sunpaper.timer "$pkgdir/usr/lib/systemd/user/sunpaper.timer"
+    install -D -m644 extra/aur/sunpaper.service "$pkgdir/usr/lib/systemd/user/sunpaper.service"
+    install -D -m644 extra/aur/sunpaper.timer "$pkgdir/usr/lib/systemd/user/sunpaper.timer"
 }

--- a/extra/aur/PKGBUILD
+++ b/extra/aur/PKGBUILD
@@ -24,13 +24,6 @@ md5sums=('SKIP')
 pkgver() {
 	cd "$srcdir/${pkgname%-git}"
 
-
-# The examples below are not absolute and need to be adapted to each repo. The
-# primary goal is to generate version numbers that will increase according to
-# pacman's version comparisons with later commits to the repo. The format
-# VERSION='VER_NUM.rREV_NUM.HASH', or a relevant subset in case VER_NUM or HASH
-# are not available, is recommended.
-
 # Git, tags available
 	# printf "%s" "$(git describe --long | sed 's/\([^-]*-\)g/r\1/;s/-/./g')"
 

--- a/extra/aur/sunpaper.service
+++ b/extra/aur/sunpaper.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Sunpaper
+After=network.target
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartSec=1
+ExecStart=/usr/bin/sunpaper.sh
+
+[Install]
+WantedBy=default.target

--- a/extra/aur/sunpaper.timer
+++ b/extra/aur/sunpaper.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run sunpaper
+
+[Timer]
+OnBootSec=15min
+OnUnitActiveSec=15min
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
This PR creates the necessary AUR makepkg to install on arch based system.

It provides the necessary systemd user's timer to start this periodically. To enable them, after installing this package, use:

```
systemctl --user start sunpaper.timer
```

See more details at: https://wiki.archlinux.org/index.php/Systemd/Timers

For aur installation in the `extra/aur` dir run:

```
makepg --install
```